### PR TITLE
fix thee echo display error

### DIFF
--- a/mgmt-hub/README.md
+++ b/mgmt-hub/README.md
@@ -57,7 +57,7 @@ Then you can run these commands:
     "destinationType": "pattern-ibm.helloworld"
   }
   EOF
-  echo -e "foo\nbar" > mms-file
+  echo "foo\nbar" > mms-file
   hzn mms object publish -m mms-meta.json -f mms-file
   ```
 


### PR DESCRIPTION
I have tried to learn about the horizon `all-in-one` setup process in Mac, I fond this error:  there is a extra str `-e` of the mss file.
```
hzn mms object download -t stuff -i mms-file -f mms-file.downloaded
Downloading objectData of object mms-file saved to file mms-file.downloaded
huleis-mbp:mgmt-hub root# ls -ltr
total 176
-rw-r--r--  1 llhu  staff   6001 Nov 30 15:57 README.md
-rw-r--r--  1 llhu  staff   1632 Nov 30 15:57 agbot-tmpl.json
-rw-r--r--  1 llhu  staff    220 Nov 30 15:57 css-tmpl.conf
-rwxr-xr-x  1 llhu  staff  34134 Nov 30 15:57 deploy-mgmt-hub.sh
-rw-r--r--  1 llhu  staff    330 Nov 30 15:57 exchange-tmpl.json
-rw-r--r--  1 llhu  staff   5034 Nov 30 16:00 docker-compose.yml
-rwxr-xr-x  1 llhu  staff   7814 Nov 30 16:00 test-sdo.sh
-rw-r--r--  1 root  staff    111 Nov 30 16:25 node.policy.json
-rw-r--r--  1 root  staff    132 Nov 30 16:52 mms-meta.json
-rw-r--r--  1 root  staff     11 Nov 30 16:52 mms-file
-rw-r--r--  1 root  staff     11 Nov 30 16:52 mms-file.downloaded
huleis-mbp:mgmt-hub root# cat mms-file.downloaded
-e foo
bar
```