### PR TITLE
open up permissions on default config

### DIFF
--- a/mgmt-hub/deploy-mgmt-hub.sh
+++ b/mgmt-hub/deploy-mgmt-hub.sh
@@ -506,6 +506,7 @@ mkdir -p /etc/horizon   # putting the config files here because they are mounted
 cat $TMP_DIR/exchange-tmpl.json | envsubst > /etc/horizon/exchange.json
 cat $TMP_DIR/agbot-tmpl.json | envsubst > /etc/horizon/agbot.json
 cat $TMP_DIR/css-tmpl.conf | envsubst > /etc/horizon/css.conf
+chmod a+r /etc/horizon/*
 
 # Start mgmt hub services
 echo "----------- Downloading/starting Horizon management hub services..."


### PR DESCRIPTION
This fixes issue #33

The install script has made some assumptions on the users umask when creating the default config files.  In my case this left the config files as only readable by root, hence the exchange api and agbot failed to start.

with this change they started OK.