### PR TITLE
Add support for Ubuntu 20.04 LTS

### DIFF
--- a/mgmt-hub/README.md
+++ b/mgmt-hub/README.md
@@ -8,8 +8,12 @@ Run the following command to deploy the Horizon components on your current host.
 
 **Notes:**
 
-- This is currently **only supported on Ubuntu 18.x and macOS**
+- The main script is currently **only supported on Ubuntu 18.x, Ubuntu 20.x and macOS**
+  - The SDO test `test-sdo.sh` is only supported on Ubuntu 18.x
 - The command below must be **run as root**. If you need to use **sudo** to become root, run `sudo -i`, and then run the command below as shown.
+- If running on **Ubuntu**:
+  - If you are setting up a fresh Ubuntu installation to try Horizon, please do *not* select Docker during the installation, to avoid potential compatibility problems. This script will install the latest version of Docker using apt, via Docker's own repositories.
+  - If you have chosen to install Docker during the Ubuntu installation, you can undo this after installing Ubuntu. Log into the system, wait for about half a minute if necessary, then run ``sudo snap remove docker``.
 - If running on **macOS**:
   - You must [install docker](https://docs.docker.com/docker-for-mac/install) yourself before running this script.
   - You must install prerequisites: jq, gettext, and socat. If you have [brew](https://brew.sh/) installed, you can install these prerequisites with: `brew install jq gettext socat`

--- a/mgmt-hub/README.md
+++ b/mgmt-hub/README.md
@@ -11,9 +11,8 @@ Run the following command to deploy the Horizon components on your current host.
 - The main script is currently **only supported on Ubuntu 18.x, Ubuntu 20.x and macOS**
   - The SDO test `test-sdo.sh` is only supported on Ubuntu 18.x
 - The command below must be **run as root**. If you need to use **sudo** to become root, run `sudo -i`, and then run the command below as shown.
-- If running on **Ubuntu**:
-  - If you are setting up a fresh Ubuntu installation to try Horizon, please do *not* select Docker during the installation, to avoid potential compatibility problems. This script will install the latest version of Docker using apt, via Docker's own repositories.
-  - If you have chosen to install Docker during the Ubuntu installation, you can undo this after installing Ubuntu. Log into the system, wait for about half a minute if necessary, then run ``sudo snap remove docker``.
+- If running on **Ubuntu** or any other distribution with the **Snap** package manager:
+  - This script is not yet compatible with Docker installed via Snap. Please use this script only with non-Snap versions of Docker. Alternatively, remove the existing Docker snap if feasible and allow the script to reinstall the latest version of Docker.
 - If running on **macOS**:
   - You must [install docker](https://docs.docker.com/docker-for-mac/install) yourself before running this script.
   - You must install prerequisites: jq, gettext, and socat. If you have [brew](https://brew.sh/) installed, you can install these prerequisites with: `brew install jq gettext socat`

--- a/mgmt-hub/deploy-mgmt-hub.sh
+++ b/mgmt-hub/deploy-mgmt-hub.sh
@@ -7,7 +7,10 @@ usage() {
     cat << EndOfMessage
 Usage: ${0##*/} [-h] [-v] [-s | -u | -S | -r <container>] [-P]
 
-Deploys the Open Horizon management hub services, agent, and CLI on this host. Currently only supported on Ubuntu 18.04 and macOS (the macOS support is experimental).
+Deploys the Open Horizon management hub services, agent, and CLI on this host. Currently supports the following operating systems:
+
+* Ubuntu (recent LTS releases 18.04 and 20.04)
+* macOS (experimental)
 
 Flags:
   -S    Stop the management hub services and agent (instead of starting them). This flag is necessary instead of you simply running 'docker-compose down' because docker-compose.yml contains environment variables that must be set.
@@ -211,6 +214,14 @@ isMacOS() {
 
 isUbuntu18() {
     if [[ "$DISTRO" == 'Ubuntu 18.'* ]]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+isUbuntu20() {
+    if [[ "$DISTRO" == 'Ubuntu 20.'* ]]; then
 		return 0
 	else
 		return 1
@@ -427,8 +438,8 @@ if [[ -z "$EXCHANGE_ROOT_PW" || -z "$EXCHANGE_ROOT_PW_BCRYPTED" ]]; then
     fatal 1 "these environment variables must be set: EXCHANGE_ROOT_PW, EXCHANGE_ROOT_PW_BCRYPTED"
 fi
 ensureWeAreRoot
-if ! isMacOS && ! isUbuntu18; then
-    fatal 1 "the host must be Ubuntu 18.x or macOS"
+if ! isMacOS && ! isUbuntu18 && ! isUbuntu20; then
+    fatal 1 "the host must be Ubuntu LTS (18.x or 20.x), or macOS"
 fi
 confirmCmds grep awk curl   # these should be automatically available on all the OSes we support
 echo "Management hub services will listen on $HZN_LISTEN_IP"


### PR DESCRIPTION
Hi, here's my hack to enable support for Ubuntu 20.x (see #35). This change only affects the main deployment script ``deploy-mgmt-hub.sh``;  Ubuntu 20 support has not been enabled for the SDO test script ``test-sdo.sh`` as I could not get it to finish on any of my test systems due to problems with importing the device vouchers.
