### PR TITLE
Issue 11: Enable HTTPS for all-in-1

### DIFF
--- a/mgmt-hub/README.md
+++ b/mgmt-hub/README.md
@@ -48,6 +48,7 @@ To view resources in the Horizon exchange, first export environment variables `H
 - View your node: `hzn exchange node list`
 - View your user in your org: `hzn exchange user list`
 - Use the verbose flag to view the exchange REST APIs the `hzn` command calls, for example: `hzn exchange user list -v`
+- View the public files in CSS that `agent-install.sh` can use to install/register the agent on edge nodes: `hzn mms -o IBM object list -d -t agent_files`
 - Create an MMS file:
 
   ```bash

--- a/mgmt-hub/agbot-tmpl.json
+++ b/mgmt-hub/agbot-tmpl.json
@@ -23,7 +23,7 @@
         "NewContractIntervalS": 5,
         "ProcessGovernanceIntervalS": 5,
         "IgnoreContractWithAttribs": "ethereum_account",
-        "ExchangeURL": "${HZN_TRANSPORT}://exchange-api:8080/v1",
+        "ExchangeURL": "http://exchange-api:8080/v1",
         "ExchangeId": "${EXCHANGE_SYSTEM_ORG}/${AGBOT_ID}",
         "ExchangeToken":"${AGBOT_TOKEN}",
         "ExchangeVersionCheckIntervalM": 1,
@@ -36,8 +36,11 @@
         "PurgeArchivedAgreementHours": 1,
         "CheckUpdatedPolicyS": 7,
         "CSSURL": "${HZN_TRANSPORT}://css-api:8080",
+        "CSSSSLCert": "${SECURE_API_SERVER_CERT}",
         "SecureAPIListenHost": "0.0.0.0",
         "SecureAPIListenPort": "8083",
+        "SecureAPIServerKey": "${SECURE_API_SERVER_KEY}",
+        "SecureAPIServerCert": "${SECURE_API_SERVER_CERT}",
         "AgreementBatchSize": 1300
     },
     "ArchSynonyms": {

--- a/mgmt-hub/css-tmpl.conf
+++ b/mgmt-hub/css-tmpl.conf
@@ -1,7 +1,10 @@
 NodeType CSS
-ListeningType unsecure
+ListeningType ${CSS_LISTENING_TYPE}
 UnsecureListeningPort 8080
-CommunicationProtocol ${HZN_TRANSPORT}
+SecureListeningPort 8080
+ServerCertificate /home/cssuser/keys/${CERT_BASE_NAME}.crt
+ServerKey /home/cssuser/keys/${CERT_BASE_NAME}.key
+CommunicationProtocol HTTP
 LogLevel INFO
 LogTraceDestination stdout
 TraceLevel INFO

--- a/mgmt-hub/docker-compose-agbot2.yml
+++ b/mgmt-hub/docker-compose-agbot2.yml
@@ -21,6 +21,8 @@ services:
       - horizonnet
     volumes:
       - ${ETC}/horizon/agbot.json:/etc/horizon/anax.json.tmpl:${VOLUME_MODE}
+      # deploy-mgmt-hub.sh will ensure this dir is empty if we want to use http
+      - ${CERT_DIR}:/home/agbotuser/keys:${VOLUME_MODE}
       # when docker mounts this it "inherits" the permissions of the existing msgKey dir (which the agbot dockerfile sets the permissions correctly)
       - agbotmsgkeyvol:/var/horizon/msgKey
     #environment:

--- a/mgmt-hub/docker-compose.yml
+++ b/mgmt-hub/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - horizonnet
     volumes:
       - ${ETC}/horizon/agbot.json:/etc/horizon/anax.json.tmpl:${VOLUME_MODE}
+      # deploy-mgmt-hub.sh will ensure this dir is empty if we want to use http
+      - ${CERT_DIR}:/home/agbotuser/keys:${VOLUME_MODE}
       # when docker mounts this it "inherits" the permissions of the existing msgKey dir (which the agbot dockerfile sets the permissions correctly)
       - agbotmsgkeyvol:/var/horizon/msgKey
     #environment:
@@ -90,12 +92,14 @@ services:
       - horizonnet
     volumes:
       - ${ETC}/horizon/css.conf:/etc/edge-sync-service/sync.conf.tmpl:${VOLUME_MODE}
-      #todo: why is this needed in this container?
-      - mongovol:/var/edge-sync-service/persist
+      # deploy-mgmt-hub.sh will ensure this dir is empty if we want to use http
+      - ${CERT_DIR}:/home/cssuser/keys:${VOLUME_MODE}
+      #todo: i do not think this needed in this container?
+      #- mongovol:/var/edge-sync-service/persist
     environment:
-      - HZN_EXCHANGE_URL=${HZN_TRANSPORT}://exchange-api:8080/v1
+      - HZN_EXCHANGE_URL=http://exchange-api:8080/v1
     healthcheck:
-      test: test $$(curl -sS -w %{http_code} -u ${EXCHANGE_USER_ORG}/admin:${EXCHANGE_USER_ADMIN_PW} -o /dev/null http://localhost:8080/api/v1/health) -eq 200
+      test: test $$(curl -sS -w %{http_code} -k -u ${EXCHANGE_USER_ORG}/admin:${EXCHANGE_USER_ADMIN_PW} -o /dev/null ${HZN_TRANSPORT}://localhost:8080/api/v1/health) -eq 200
       interval: 15s
       timeout: 5s
       retries: 3
@@ -129,10 +133,12 @@ services:
       - horizonnet
     volumes:
       - ocsdb:${SDO_OCS_DB_PATH}
+      # deploy-mgmt-hub.sh will ensure this dir is empty if we want to use http
+      - ${CERT_DIR}:/home/sdouser/ocs-api-dir/keys:${VOLUME_MODE}
     # intentionally omitting HZN_MGMT_HUB_CERT from the environment section, since we use http in this environment
     environment:
-      - HZN_EXCHANGE_URL=${HZN_TRANSPORT}://${HZN_LISTEN_IP}:${EXCHANGE_PORT}/v1
-      - EXCHANGE_INTERNAL_URL=${HZN_TRANSPORT}://exchange-api:8080/v1
+      - HZN_EXCHANGE_URL=http://${HZN_LISTEN_IP}:${EXCHANGE_PORT}/v1
+      - EXCHANGE_INTERNAL_URL=http://exchange-api:8080/v1
       - HZN_FSS_CSSURL=${HZN_TRANSPORT}://${HZN_LISTEN_IP}:${CSS_PORT}/
       - HZN_ORG_ID=${EXCHANGE_USER_ORG}
       - SDO_OWNER_SVC_HOST=${HZN_LISTEN_IP}


### PR DESCRIPTION
See [issue 11](https://github.com/open-horizon/devops/issues/11) for the design and changes.

**Note:** This doesn't yet configure the exchange to use https, because the exchange doesn't support that yet (soon).

Also made these 2 unrelated enhancements:

- added HZN_LISTEN_PUBLIC_IP for when script can't automatically determine public IP
- under special circumstances the user can disable downloading some or all of these: `OH_DONT_DOWNLOAD='deploy-mgmt-hub.sh test-sdo.sh docker-compose.yml docker-compose-agbot2.yml exchange-tmpl.json agbot-tmpl.json css-tmpl.conf'`


Signed-off-by: Bruce Potter <bp@us.ibm.com>