### PR TITLE
Issue 93 - Agbot container stuck in 'restarting' status

### DIFF
--- a/mgmt-hub/deploy-mgmt-hub.sh
+++ b/mgmt-hub/deploy-mgmt-hub.sh
@@ -187,7 +187,7 @@ export CSS_TRACE_ROOT_PATH=${CSS_TRACE_ROOT_PATH:-/var/edge-sync-service/trace}
 export CSS_MONGO_AUTH_DB_NAME=${CSS_MONGO_AUTH_DB_NAME:-admin}
 
 export POSTGRES_IMAGE_NAME=${POSTGRES_IMAGE_NAME:-postgres}
-export POSTGRES_IMAGE_TAG=${POSTGRES_IMAGE_TAG:-latest}   # or can be set to stable or a specific version
+export POSTGRES_IMAGE_TAG=${POSTGRES_IMAGE_TAG:-13}   # or can be set to stable or a specific version
 export POSTGRES_PORT=${POSTGRES_PORT:-5432}
 export POSTGRES_USER=${POSTGRES_USER:-admin}
 export EXCHANGE_DATABASE=${EXCHANGE_DATABASE:-exchange}   # the db the exchange uses in the postgres instance


### PR DESCRIPTION
Signed-off-by: linggao <linggao@us.ibm.com>
Make postgres version 13 as default because version 14 does not work with current agbot.