### PR TITLE
Issue-144: fixed broken link, added front matter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,12 @@
+---
+copyright:
+years: 2023
+lastupdated: "2023-02-17"
+title: "All-in-One Mgmt Hub"
+
+parent: Management Hub
+nav_order: 2
+---
 # Horizon Management Hub
 
 ## <a name="deploy-all-in-one">Deploy All-in-One Horizon Management Hub, Agent and CLI</a>
@@ -199,7 +208,7 @@ Using a Virtual Machine (VM) allows you to learn and experiment with Open Horizo
 Oracle VM [VirtualBox](https://www.virtualbox.org/wiki/Downloads) is a virtualization application that runs on {{site.data.keyword.macOS_notm}}, Solaris and Windows as well as Linux.
 Its Virtual Machine Manager user interface has a reasonable learning curve for beginners while keeping advanced settings within easy reach.
 
-The Open Horizon website has [a video](https://open-horizon.github.io/common-requests/install.html) detailing the process of setting up a VM in VirtualBox for use with the All-in-One environment.
+The Open Horizon website has [a video](/common-requests/install/) detailing the process of setting up a VM in VirtualBox for use with the All-in-One environment.
 
 This is a summary of the setup process:
 


### PR DESCRIPTION
Something strange here ... when I went in to fix the broken link, I noticed that the markdown was also missing front matter entirely.  Yet the page on the site supposedly copied from here actually _had_ the front matter.  This is a sign that this file may not be the one copied over.  I added the missing front matter.