### PR TITLE
sdo: fix tests and remove outstanding sdo refs

### DIFF
--- a/mgmt-hub/deploy-mgmt-hub.sh
+++ b/mgmt-hub/deploy-mgmt-hub.sh
@@ -220,9 +220,6 @@ export FDO_OWN_SVC_VERBOSE=${FDO_OWN_SVC_VERBOSE:-false}
 export FDO_OPS_SVC_HOST=${FDO_OPS_SVC_HOST:-${HZN_LISTEN_IP}:${FDO_OWN_SVC_PORT}}
 export FIDO_DEVICE_ONBOARD_REL_VER=${FIDO_DEVICE_ONBOARD_REL_VER:-1.1.7}
 
-export SDO_IMAGE_NAME=${SDO_IMAGE_NAME:-openhorizon/sdo-owner-services}
-export SDO_IMAGE_TAG=${SDO_IMAGE_TAG:-lastest}   # or can be set to stable, testing, or a specific version
-
 # Note: in this environment, we are not supporting letting them specify their own owner key pair (only using the built-in sample key pair)
 export VAULT_AUTH_PLUGIN_EXCHANGE=openhorizon-exchange
 export VAULT_PORT=${VAULT_PORT:-8200}
@@ -990,7 +987,7 @@ if [[ $0 == 'bash' || ! -f deploy-mgmt-hub.sh ]]; then
     getUrlFile $OH_DEVOPS_REPO/mgmt-hub/deploy-mgmt-hub.sh deploy-mgmt-hub.sh
     chmod +x deploy-mgmt-hub.sh
 fi
-# also leave a copy of test-mgmt-hub.sh and test-sdo.sh so they can run those afterward, if they want
+# also leave a copy of test-mgmt-hub.sh and test-fdo.sh so they can run those afterward, if they want
 getUrlFile $OH_DEVOPS_REPO/mgmt-hub/test-mgmt-hub.sh test-mgmt-hub.sh
 chmod +x test-mgmt-hub.sh
 getUrlFile $OH_DEVOPS_REPO/mgmt-hub/test-fdo.sh test-fdo.sh
@@ -1069,7 +1066,7 @@ if [[ -n "$STOP" ]]; then
 
     if [[ -n "$PURGE" && $KEEP_DOCKER_IMAGES != 'true' ]]; then   # KEEP_DOCKER_IMAGES is a hidden env var for convenience while developing this script
         echo "Removing Open-horizon Docker images..."
-        runCmdQuietly docker rmi ${AGBOT_IMAGE_NAME}:${AGBOT_IMAGE_TAG} ${FDO_OWN_SVC_IMAGE_NAME}:${FDO_OWN_SVC_IMAGE_TAG} ${EXCHANGE_IMAGE_NAME}:${EXCHANGE_IMAGE_TAG} ${CSS_IMAGE_NAME}:${CSS_IMAGE_TAG} ${POSTGRES_IMAGE_NAME}:${POSTGRES_IMAGE_TAG} ${MONGO_IMAGE_NAME}:${MONGO_IMAGE_TAG} ${SDO_IMAGE_NAME}:${SDO_IMAGE_TAG} ${VAULT_IMAGE_NAME}:${VAULT_IMAGE_TAG}
+        runCmdQuietly docker rmi ${AGBOT_IMAGE_NAME}:${AGBOT_IMAGE_TAG} ${FDO_OWN_SVC_IMAGE_NAME}:${FDO_OWN_SVC_IMAGE_TAG} ${EXCHANGE_IMAGE_NAME}:${EXCHANGE_IMAGE_TAG} ${CSS_IMAGE_NAME}:${CSS_IMAGE_TAG} ${POSTGRES_IMAGE_NAME}:${POSTGRES_IMAGE_TAG} ${MONGO_IMAGE_NAME}:${MONGO_IMAGE_TAG} ${VAULT_IMAGE_NAME}:${VAULT_IMAGE_TAG}
     fi
     exit
 fi

--- a/mgmt-hub/test-mgmt-hub.sh
+++ b/mgmt-hub/test-mgmt-hub.sh
@@ -161,14 +161,14 @@ testMgmtHubServices() {
     assertTrue "docker ps --filter 'name=exchange-api' --format '{{ .Status }}' | grep -q '(healthy)' "
     assertTrue "docker ps --filter 'name=agbot' --format '{{ .Status }}' | grep -q '(healthy)' "
     assertTrue "docker ps --filter 'name=css-api' --format '{{ .Status }}' | grep -q '(healthy)' "
-    assertTrue "docker ps --filter 'name=sdo-owner-services' --format '{{ .Status }}' | grep -q '(healthy)' "
+    assertTrue "docker ps --filter 'name=fdo-owner-services' --format '{{ .Status }}' | grep -q '(healthy)' "
 }
 
 testDefaultsFile() {
     assertTrue "grep -q -E '^HZN_EXCHANGE_URL=http' /etc/default/horizon"
     assertTrue "grep -q -E '^HZN_FSS_CSSURL=http' /etc/default/horizon"
     assertTrue "grep -q -E '^HZN_AGBOT_URL=http' /etc/default/horizon"
-    assertTrue "grep -q -E '^HZN_SDO_SVC_URL=http' /etc/default/horizon"
+    assertTrue "grep -q -E '^HZN_FDO_SVC_URL=http' /etc/default/horizon"
     assertTrue "grep -q -E '^HZN_DEVICE_ID=.+' /etc/default/horizon"
     if grep -q -E '^HZN_FSS_CSSURL=https:' /etc/default/horizon; then
         assertTrue "grep -q -E '^HZN_MGMT_HUB_CERT_PATH=.+' /etc/default/horizon"


### PR DESCRIPTION
Tests included in `test-mgmt-hub.sh` were still looking for sdo-related container and configuration URL, and that made the test fail.

Also, remove from `deploy-mgmt-hub.sh` any outstanding reference to SDO, since it is no longer part of the OpenHorizon deployment.

Fixes: #165