### PR TITLE
Update Mongo connection string to compatible format

### DIFF
--- a/mgmt-hub/css-tmpl.conf
+++ b/mgmt-hub/css-tmpl.conf
@@ -10,7 +10,7 @@ LogTraceDestination ${CSS_LOG_TRACE_DESTINATION}
 LogRootPath ${CSS_LOG_ROOT_PATH}
 TraceLevel ${CSS_TRACE_LEVEL}
 TraceRootPath ${CSS_TRACE_ROOT_PATH}
-MongoAddressCsv mongo:${MONGO_PORT}
+MongoAddressCsv mongodb://mongo:${MONGO_PORT}
 MongoUseSSL false
 MongoAuthDbName ${CSS_MONGO_AUTH_DB_NAME}
 PersistenceRootPath ${CSS_PERSISTENCE_PATH}


### PR DESCRIPTION
edge-sync-service was updated recently in PR #149 to enable mongo 6 support.

The css-templ.conf config in devops was not updated as part of that effort, and was out of sync with the new format.

See common/config.go in https://github.com/open-horizon/edge-sync-service/commit/ba8f438f307d111411623a781e0649a34250b483

Fixes #174 